### PR TITLE
refactor: adopt shared Flutter foundation

### DIFF
--- a/.github/workflows/shared-quality.yml
+++ b/.github/workflows/shared-quality.yml
@@ -8,4 +8,4 @@ on:
 
 jobs:
   quality:
-    uses: brandonp2412/Flexify/.github/workflows/flutter-quality.yml@2e2711a67022d0f69b63512a2320fc69a4ab4b1e
+    uses: brandonp2412/Flexify/.github/workflows/flutter-quality.yml@9cbb2208242a39aa4da3db833bac422891eeb5da

--- a/.github/workflows/shared-quality.yml
+++ b/.github/workflows/shared-quality.yml
@@ -1,0 +1,11 @@
+name: Shared Flutter quality
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  quality:
+    uses: brandonp2412/Flexify/.github/workflows/flutter-quality.yml@2e2711a67022d0f69b63512a2320fc69a4ab4b1e

--- a/.github/workflows/sync-shared-lock.yml
+++ b/.github/workflows/sync-shared-lock.yml
@@ -1,0 +1,33 @@
+name: Sync shared dependency lockfile
+
+on:
+  push:
+    branches: [cross-project-foundation]
+    paths:
+      - pubspec.yaml
+
+permissions:
+  contents: write
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          fetch-depth: 0
+      - name: Resolve dependencies
+        run: flutter/bin/flutter pub get
+      - name: Commit generated lockfile
+        shell: bash
+        run: |
+          if git diff --quiet -- pubspec.lock; then
+            exit 0
+          fi
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git add pubspec.lock
+          git commit -m 'chore: sync shared dependency lockfile'
+          git push

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,11 @@
+# Project Instructions
+
+Follow the repository-specific engineering rules in `CLAUDE.md` in addition to these instructions.
+
+# Cross-Project Flutter Reuse
+
+- Before implementing or fixing generic Flutter, Android, CI, navigation, theming, lifecycle, startup, logging, import/export, or performance behavior, search the sibling Flutter repositories (`Flexify`, `FitBook`, `MarketMonk`, `Quitter`, and `BlockDrop`) for an existing solution or regression test.
+- Reusable app-agnostic Flutter infrastructure should come from the `frisbee_flutter_foundation` package hosted under `packages/flutter_foundation` in Flexify rather than being copied between apps.
+- Shared CI behavior should use the reusable workflows hosted by Flexify; keep only app-specific orchestration and parameters locally.
+- When a generic fix is made here, check whether the same failure pattern exists in sibling apps before considering the task complete.
+- Keep shared-package and shared-workflow Git references pinned to a concrete commit and update the pin deliberately.

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,18 +1,21 @@
+import 'dart:async';
+
+import 'package:dynamic_color/dynamic_color.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
-import 'package:quitter/l10n/generated/app_localizations.dart';
 import 'package:flutter_svg/svg.dart';
+import 'package:frisbee_flutter_foundation/frisbee_flutter_foundation.dart';
 import 'package:provider/provider.dart';
-import 'package:dynamic_color/dynamic_color.dart';
 import 'package:quitter/addiction_provider.dart';
 import 'package:quitter/app_scheme.dart';
+import 'package:quitter/app_theme_mode.dart';
 import 'package:quitter/home_page.dart';
 import 'package:quitter/journal_page.dart';
-import 'package:quitter/stats_page.dart';
+import 'package:quitter/l10n/generated/app_localizations.dart';
 import 'package:quitter/pin_page.dart';
 import 'package:quitter/settings_provider.dart';
+import 'package:quitter/stats_page.dart';
 import 'package:quitter/tasks.dart';
-import 'package:quitter/app_theme_mode.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 final rootScaffoldMessenger = GlobalKey<ScaffoldMessengerState>();
@@ -45,27 +48,34 @@ Future<void> _migrateHiddenToDeleted() async {
   await prefs.setBool('migrated_v2_hide_to_delete', true);
 }
 
-void main() async {
-  WidgetsFlutterBinding.ensureInitialized();
+Future<void> main() async {
+  runZonedGuarded(
+    () async {
+      WidgetsFlutterBinding.ensureInitialized();
+      await CrashLogger.install(fileName: 'quitter-crash.log');
 
-  await _migrateHiddenToDeleted();
+      await _migrateHiddenToDeleted();
 
-  final settings = SettingsProvider();
-  await settings.loadPreferences();
-  final addiction = AddictionProvider();
-  await addiction.loadAddictions();
+      final settings = SettingsProvider();
+      await settings.loadPreferences();
+      final addiction = AddictionProvider();
+      await addiction.loadAddictions();
 
-  cancelTasks();
-  setupTasks();
+      cancelTasks();
+      setupTasks();
 
-  runApp(
-    MultiProvider(
-      providers: [
-        ChangeNotifierProvider(create: (context) => settings),
-        ChangeNotifierProvider(create: (context) => addiction),
-      ],
-      child: const QuitterApp(),
-    ),
+      runApp(
+        MultiProvider(
+          providers: [
+            ChangeNotifierProvider(create: (context) => settings),
+            ChangeNotifierProvider(create: (context) => addiction),
+          ],
+          child: const QuitterApp(),
+        ),
+      );
+    },
+    (error, stack) =>
+        CrashLogger.instance?.record(error, stack, context: 'zone'),
   );
 }
 
@@ -117,8 +127,10 @@ class _QuitterAppState extends State<QuitterApp>
     return Consumer<SettingsProvider>(
       builder: (context, settings, child) {
         final expectedTabCount = settings.showJournal ? 3 : 2;
-        if (_tabController.length != expectedTabCount)
+        if (_tabController.length != expectedTabCount) {
+          _tabController.dispose();
           _tabController = TabController(length: expectedTabCount, vsync: this);
+        }
 
         return DynamicColorBuilder(
           builder: (ColorScheme? lightDynamic, ColorScheme? darkDynamic) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,6 +9,11 @@ dependencies:
     sdk: flutter
   flutter_localizations:
     sdk: flutter
+  frisbee_flutter_foundation:
+    git:
+      url: https://github.com/brandonp2412/Flexify.git
+      ref: 2e2711a67022d0f69b63512a2320fc69a4ab4b1e
+      path: packages/flutter_foundation
   cupertino_icons: ^1.0.8
   shared_preferences: ^2.5.3
   provider: ^6.1.5
@@ -33,7 +38,7 @@ dev_dependencies:
     sdk: flutter
   patrol: 4.8.0
   flutter_lints: ^6.0.0
-  flutter_launcher_icons: ^0.14.4 # Add this line
+  flutter_launcher_icons: ^0.14.4
   integration_test:
     sdk: flutter
   flutter_driver:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: quitter
 description: "Quit addictions with Free and Open Source software"
-publish_to: 'none'
+publish_to: "none"
 version: 1.1.42+1221
 environment:
   sdk: ^3.9.0


### PR DESCRIPTION
Superseded by #109. The shared foundation dependency/workflow call was intentionally removed; Quitter now owns the same hardening locally.